### PR TITLE
Refaktorerer Arbeidssituasjon til Enum

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "1.4.2.91f146b"
+val dusseldorfKtorVersion = "1.4.1.15e3c67"
 val ktorVersion = ext.get("ktorVersion").toString()
 val mainClass = "no.nav.omsorgspenger.AppKt"
 
@@ -12,7 +12,7 @@ plugins {
 
 buildscript {
     // Henter ut diverse dependency versjoner, i.e. ktorVersion.
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/91f146ba9e4af45ab25d7ead0a2240121ee74f57/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/15e3c67346dcf8d8c5d81c010f1fe648baf603e9/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "1.4.1.15e3c67"
+val dusseldorfKtorVersion = "1.4.2.91f146b"
 val ktorVersion = ext.get("ktorVersion").toString()
 val mainClass = "no.nav.omsorgspenger.AppKt"
 
@@ -12,7 +12,7 @@ plugins {
 
 buildscript {
     // Henter ut diverse dependency versjoner, i.e. ktorVersion.
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/15e3c67346dcf8d8c5d81c010f1fe648baf603e9/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/91f146ba9e4af45ab25d7ead0a2240121ee74f57/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/KomplettSoknad.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/KomplettSoknad.kt
@@ -10,7 +10,7 @@ data class KomplettSoknad(
     val mottatt: ZonedDateTime,
     val kroniskEllerFunksjonshemming: Boolean,
     val søker: Søker,
-    val arbeidssituasjon: List<String>,
+    val arbeidssituasjon: List<Arbeidssituasjon>,
     val barn: BarnDetaljer,
     val relasjonTilBarnet: SøkerBarnRelasjon? = null,
     val sammeAdresse: Boolean?,

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/Søknad.kt
@@ -1,5 +1,6 @@
 package no.nav.omsorgspenger.soknad
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonValue
 import java.net.URL
@@ -8,7 +9,7 @@ import java.time.LocalDate
 data class Søknad(
     val nyVersjon: Boolean,
     val språk: String,
-    val arbeidssituasjon: List<String>,
+    val arbeidssituasjon: List<Arbeidssituasjon>,
     val kroniskEllerFunksjonshemming: Boolean,
     val barn: BarnDetaljer,
     val sammeAdresse: Boolean?,
@@ -55,3 +56,8 @@ enum class SøkerBarnRelasjon(@JsonValue val relasjon: String) {
     FOSTERFORELDER("fosterforelder")
 }
 
+enum class Arbeidssituasjon(){
+    @JsonAlias("selvstendigNæringsdrivende") SELVSTENDIG_NÆRINGSDRIVENDE,
+    @JsonAlias("arbeidstaker") ARBEIDSTAKER,
+    @JsonAlias("frilanser") FRILANSER
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
@@ -32,18 +32,6 @@ internal fun Søknad.valider() {
             )
         )
     }
-    arbeidssituasjon.mapIndexed { index, situasjon ->
-        if (situasjon.isNullOrBlank()) {
-            violations.add(
-                Violation(
-                    parameterName = "arbeidssituasjon[$index]",
-                    parameterType = ParameterType.ENTITY,
-                    reason = "List over arbeidssituasjon kan ikke inneholde null eller tomme verdier",
-                    invalidValue = situasjon
-                )
-            )
-        }
-    }
 
 /*
     // legeerklaring

--- a/src/test/kotlin/no/nav/omsorgspenger/SoknadUtils.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SoknadUtils.kt
@@ -16,7 +16,7 @@ class SoknadUtils {
                 {
                   "nyVersjon": true,
                   "språk": "nb",
-                  "arbeidssituasjon": ["Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"],
+                  "arbeidssituasjon": ["arbeidstaker", "frilanser", "selvstendigNæringsdrivende"],
                   "kroniskEllerFunksjonshemming": true,
                   "barn": {
                     "navn": "Ole Dole Doffen",
@@ -67,7 +67,7 @@ class SoknadUtils {
                 {
                   "nyVersjon": true,
                   "språk": "nb",
-                  "arbeidssituasjon": ["Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"],
+                  "arbeidssituasjon": ["arbeidstaker", "frilanser", "selvstendigNæringsdrivende"],
                   "kroniskEllerFunksjonshemming": true,
                   "barn": {
                     "fødselsdato": "2005-02-23",
@@ -115,7 +115,7 @@ class SoknadUtils {
                 {
                   "nyVersjon": true,
                   "språk": "nb",
-                  "arbeidssituasjon": ["Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"],
+                  "arbeidssituasjon": ["arbeidstaker", "frilanser", "selvstendigNæringsdrivende"],
                   "kroniskEllerFunksjonshemming": true,
                   "barn": {
                     "fødselsdato": "2005-01-23"

--- a/src/test/kotlin/no/nav/omsorgspenger/SoknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SoknadValidationTest.kt
@@ -22,7 +22,7 @@ internal class SøknadValideringsTest {
         Søknad(
             nyVersjon = false,
             språk = "nb",
-            arbeidssituasjon = listOf("Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"),
+            arbeidssituasjon = listOf(Arbeidssituasjon.ARBEIDSTAKER),
             kroniskEllerFunksjonshemming = true,
             sammeAdresse = true,
             harBekreftetOpplysninger = true,
@@ -64,8 +64,8 @@ internal class SøknadValideringsTest {
         val søknad = Søknad(
             nyVersjon = false,
             språk = "nb",
-            arbeidssituasjon = listOf("Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"),
             kroniskEllerFunksjonshemming = true,
+            arbeidssituasjon = listOf(Arbeidssituasjon.ARBEIDSTAKER),
             sammeAdresse = true,
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true,
@@ -108,8 +108,8 @@ internal class SøknadValideringsTest {
         Søknad(
             nyVersjon = false,
             språk = "nb",
-            arbeidssituasjon = listOf("Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"),
             kroniskEllerFunksjonshemming = true,
+            arbeidssituasjon = listOf(Arbeidssituasjon.ARBEIDSTAKER),
             sammeAdresse = true,
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true,
@@ -138,7 +138,7 @@ internal class SøknadValideringsTest {
         Søknad(
             nyVersjon = false,
             språk = "nb",
-            arbeidssituasjon = listOf("Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"),
+            arbeidssituasjon = listOf(Arbeidssituasjon.ARBEIDSTAKER),
             kroniskEllerFunksjonshemming = true,
             sammeAdresse = true,
             harBekreftetOpplysninger = true,
@@ -168,8 +168,8 @@ internal class SøknadValideringsTest {
         Søknad(
             nyVersjon = false,
             språk = "nb",
-            arbeidssituasjon = listOf("Arbeidstaker", "Frilans", "Selvstendig Næringsdrivende"),
             kroniskEllerFunksjonshemming = true,
+            arbeidssituasjon = listOf(Arbeidssituasjon.ARBEIDSTAKER),
             sammeAdresse = true,
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true,


### PR DESCRIPTION
Refaktorerer Arbeidssituasjon til å være enum og ikke en liste av Stringer. Det gjør at vi har bedre kontroll på hva som sendes inn og hva vi kan gjøre med Arbeidssituasjon i prosessering. 