### PR TITLE
Resolve informasjon av barn etter innsending

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -139,6 +139,10 @@ fun Application.omsorgpengesoknadapi() {
             baseUrl = configuration.getK9OppslagUrl(),
             apiGatewayApiKey = apiGatewayApiKey
         )
+        val barnService = BarnService(
+            barnGateway = barnGateway,
+            cache = configuration.cache()
+        )
 
         val søkerService = SøkerService(
             søkerGateway = sokerGateway
@@ -151,10 +155,9 @@ fun Application.omsorgpengesoknadapi() {
                 idTokenProvider = idTokenProvider
             )
 
+
             barnApis(
-                barnService = BarnService(
-                    barnGateway = barnGateway
-                ),
+                barnService = barnService,
                 idTokenProvider = idTokenProvider
             )
 
@@ -182,7 +185,8 @@ fun Application.omsorgpengesoknadapi() {
                     omsorgpengesøknadMottakGateway = omsorgpengesoknadMottakGateway,
                     vedleggService = vedleggService
                 ),
-                søkerService = søkerService
+                søkerService = søkerService,
+                barnService = barnService
             )
         }
 

--- a/src/main/kotlin/no/nav/omsorgspenger/Configuration.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/Configuration.kt
@@ -1,5 +1,7 @@
 package no.nav.omsorgspenger
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.ktor.config.*
 import io.ktor.util.*
 import no.nav.helse.dusseldorf.ktor.auth.EnforceEqualsOrContains
@@ -10,6 +12,7 @@ import no.nav.helse.dusseldorf.ktor.core.getRequiredList
 import no.nav.helse.dusseldorf.ktor.core.getRequiredString
 import no.nav.omsorgspenger.general.auth.ApiGatewayApiKey
 import java.net.URI
+import java.time.Duration
 
 @KtorExperimentalAPI
 data class Configuration(val config : ApplicationConfig) {
@@ -58,5 +61,20 @@ data class Configuration(val config : ApplicationConfig) {
 
     internal fun getStoragePassphrase(): String {
         return config.getRequiredString("nav.storage.passphrase", secret = true)
+    }
+
+    internal fun <K, V> cache(
+        expiry: Duration = Duration.ofMinutes(
+            config.getRequiredString(
+                "nav.cache.barn.expiry_in_minutes",
+                secret = false
+            ).toLong()
+        )
+    ): Cache<K, V> {
+        val maxSize = config.getRequiredString("nav.cache.barn.max_size", secret = false).toLong()
+        return Caffeine.newBuilder()
+            .expireAfterWrite(expiry)
+            .maximumSize(maxSize)
+            .build()
     }
 }

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
@@ -9,9 +9,9 @@ data class BarnResponse(
 
 data class Barn(
     val fødselsdato: LocalDate,
-    val fornavn: String?,
+    val fornavn: String,
     val mellomnavn: String?,
-    val etternavn: String?,
+    val etternavn: String,
     val aktørId: String?,
     @JsonIgnore var identitetsnummer: String? = null
 )

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
@@ -1,15 +1,17 @@
 package no.nav.omsorgspenger.barn
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import java.time.LocalDate
 
 data class BarnResponse(
     val barn: List<Barn>
 )
 
-data class Barn (
+data class Barn(
     val fødselsdato: LocalDate,
     val fornavn: String?,
     val mellomnavn: String?,
     val etternavn: String?,
-    val aktørId: String?
+    val aktørId: String?,
+    @JsonIgnore var identitetsnummer: String? = null
 )

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/Barn.kt
@@ -13,5 +13,5 @@ data class Barn(
     val mellomnavn: String?,
     val etternavn: String,
     val aktørId: String?,
-    @JsonIgnore var identitetsnummer: String? = null
+    @JsonIgnore var identitetsnummer: String
 )

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
@@ -85,7 +85,7 @@ class BarnGateway(
     private data class BarnOppslagResponse(val barn: List<BarnOppslagDTO>)
 
     data class BarnOppslagDTO(
-        val identitetsnummer: String? = null,
+        val identitetsnummer: String,
         val fødselsdato: LocalDate,
         val fornavn: String,
         val mellomnavn: String? = null,

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
@@ -85,6 +85,7 @@ class BarnGateway(
     private data class BarnOppslagResponse(val barn: List<BarnOppslagDTO>)
 
     data class BarnOppslagDTO(
+        val identitetsnummer: String? = null,
         val fødselsdato: LocalDate,
         val fornavn: String,
         val mellomnavn: String? = null,

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/BarnGateway.kt
@@ -3,7 +3,7 @@ package no.nav.omsorgspenger.barn
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.kittinunf.fuel.coroutines.awaitStringResponseResult
-import io.ktor.http.Url
+import io.ktor.http.*
 import no.nav.helse.dusseldorf.ktor.client.buildURL
 import no.nav.helse.dusseldorf.ktor.core.Retry
 import no.nav.helse.dusseldorf.ktor.metrics.Operation
@@ -18,28 +18,32 @@ import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
 
-class BarnGateway (
+class BarnGateway(
     baseUrl: URI,
     apiGatewayApiKey: ApiGatewayApiKey
-    ) : K9OppslagGateway(baseUrl, apiGatewayApiKey) {
+) : K9OppslagGateway(baseUrl, apiGatewayApiKey) {
 
     private companion object {
         private val logger: Logger = LoggerFactory.getLogger("nav.BarnGateway")
         private const val HENTE_BARN_OPERATION = "hente-barn"
         private val objectMapper = jacksonObjectMapper().k9SelvbetjeningOppslagKonfigurert()
 
-        private val attributter = Pair("a", listOf("barn[].aktør_id",
-            "barn[].fornavn",
-            "barn[].mellomnavn",
-            "barn[].etternavn",
-            "barn[].fødselsdato")
+        private val attributter = Pair(
+            "a", listOf(
+                "barn[].aktør_id",
+                "barn[].fornavn",
+                "barn[].mellomnavn",
+                "barn[].etternavn",
+                "barn[].fødselsdato",
+                "barn[].identitetsnummer"
+            )
         )
     }
 
     suspend fun hentBarn(
         idToken: IdToken,
-        callId : CallId
-    ) : List<BarnOppslagDTO> {
+        callId: CallId
+    ): List<BarnOppslagDTO> {
         val barnUrl = Url.buildURL(
             baseUrl = baseUrl,
             pathParts = listOf("meg"),
@@ -63,9 +67,13 @@ class BarnGateway (
             ) { httpRequest.awaitStringResponseResult() }
 
             result.fold(
-                { success -> objectMapper.readValue<BarnOppslagResponse>(success)},
+                { success -> objectMapper.readValue<BarnOppslagResponse>(success) },
                 { error ->
-                    logger.error("Error response = '${error.response.body().asString("text/plain")}' fra '${request.url}'")
+                    logger.error(
+                        "Error response = '${
+                            error.response.body().asString("text/plain")
+                        }' fra '${request.url}'"
+                    )
                     logger.error(error.toString())
                     throw IllegalStateException("Feil ved henting av informasjon om søkers barn")
                 }
@@ -76,7 +84,7 @@ class BarnGateway (
 
     private data class BarnOppslagResponse(val barn: List<BarnOppslagDTO>)
 
-    data class BarnOppslagDTO (
+    data class BarnOppslagDTO(
         val fødselsdato: LocalDate,
         val fornavn: String,
         val mellomnavn: String? = null,

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/BarnService.kt
@@ -1,12 +1,14 @@
 package no.nav.omsorgspenger.barn
 
+import com.github.benmanes.caffeine.cache.Cache
 import no.nav.omsorgspenger.general.CallId
 import no.nav.omsorgspenger.general.auth.IdToken
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class BarnService(
-    private val barnGateway: BarnGateway
+    private val barnGateway: BarnGateway,
+    private val cache: Cache<String, List<Barn>>
 ) {
     private companion object {
         private val logger: Logger = LoggerFactory.getLogger(BarnService::class.java)
@@ -15,15 +17,24 @@ class BarnService(
     internal suspend fun hentNaaverendeBarn(
         idToken: IdToken,
         callId: CallId
-    ): List<Barn> = try {
-        barnGateway.hentBarn(
-            idToken = idToken,
-            callId = callId
-            ).map { it.tilBarn() }
+    ): List<Barn> {
+        var listeOverBarnOppslag = cache.getIfPresent(idToken.getSubject().toString())
+        logger.info("Fant barn i cache.")
+        if (listeOverBarnOppslag != null) return listeOverBarnOppslag
+
+        return try {
+            val barn = barnGateway.hentBarn(
+                idToken = idToken,
+                callId = callId
+            )
+                .map { it.tilBarn() }
+            cache.put(idToken.getSubject().toString(), barn)
+            barn
         } catch (cause: Throwable) {
             logger.error("Feil ved henting av barn, returnerer en tom liste", cause)
             emptyList<Barn>()
         }
+    }
 
     private fun BarnGateway.BarnOppslagDTO.tilBarn() = Barn(
         fødselsdato = fødselsdato,

--- a/src/main/kotlin/no/nav/omsorgspenger/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/barn/BarnService.kt
@@ -37,6 +37,7 @@ class BarnService(
     }
 
     private fun BarnGateway.BarnOppslagDTO.tilBarn() = Barn(
+        identitetsnummer = identitetsnummer,
         fødselsdato = fødselsdato,
         fornavn = fornavn,
         mellomnavn = mellomnavn,

--- a/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
@@ -14,14 +14,14 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 
 private val k9FormatVersjon = Versjon.of("1.0.0")
 
-fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, barnDetaljer: BarnDetaljer): K9Søknad {
+fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker): K9Søknad {
     return K9Søknad(
         SøknadId.of(this.søknadId),
         k9FormatVersjon,
         mottatt,
         søker.tilK9Søker(),
         OmsorgspengerKroniskSyktBarn(
-            barnDetaljer.tilK9Barn(),
+            barn.tilK9Barn(),
             kroniskEllerFunksjonshemming
         )
     )

--- a/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
@@ -14,14 +14,14 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 
 private val k9FormatVersjon = Versjon.of("1.0.0")
 
-fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, barn: BarnDetaljer): K9Søknad {
+fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, barnDetaljer: BarnDetaljer): K9Søknad {
     return K9Søknad(
         SøknadId.of(this.søknadId),
         k9FormatVersjon,
         mottatt,
         søker.tilK9Søker(),
         OmsorgspengerKroniskSyktBarn(
-            barn.tilK9Barn(),
+            barnDetaljer.tilK9Barn(),
             kroniskEllerFunksjonshemming
         )
     )

--- a/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/k9format/K9Format.kt
@@ -14,7 +14,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Søker as K9Søker
 
 private val k9FormatVersjon = Versjon.of("1.0.0")
 
-fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker): K9Søknad {
+fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker, barn: BarnDetaljer): K9Søknad {
     return K9Søknad(
         SøknadId.of(this.søknadId),
         k9FormatVersjon,
@@ -29,6 +29,6 @@ fun Søknad.tilK9Format(mottatt: ZonedDateTime, søker: Søker): K9Søknad {
 
 
 fun Søker.tilK9Søker(): K9Søker = K9Søker(NorskIdentitetsnummer.of(fødselsnummer))
-fun BarnDetaljer.tilK9Barn(): K9Barn = K9Barn(NorskIdentitetsnummer.of(this.norskIdentifikator), (fødselsdato))
+fun BarnDetaljer.tilK9Barn(): K9Barn = K9Barn(NorskIdentitetsnummer.of(this.norskIdentifikator), null)
 
 

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/Søknad.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/Søknad.kt
@@ -11,21 +11,28 @@ data class Søknad(
     val søknadId: String = UUID.randomUUID().toString(),
     val språk: String,
     val kroniskEllerFunksjonshemming: Boolean,
-    val barn: BarnDetaljer,
+    var barn: BarnDetaljer,
     val sammeAdresse: Boolean?,
     val relasjonTilBarnet: SøkerBarnRelasjon? = null,
     val legeerklæring: List<URL>,
     val samværsavtale: List<URL>? = null,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean
-)
+) {
+
+    fun oppdaterBarnsIdentitetsnummer(barn: BarnDetaljer) {
+        this.barn = this.barn.copy(
+            norskIdentifikator = barn.norskIdentifikator
+        )
+    }
+}
 
 data class BarnDetaljer(
     val norskIdentifikator: String? = null,
     @JsonFormat(pattern = "yyyy-MM-dd")
     val fødselsdato: LocalDate? = null,
     val aktørId: String? = null,
-    val navn: String? = null
+    val navn: String
 ) {
     override fun toString(): String {
         return "BarnDetaljer(aktoerId=${aktørId}, navn=${navn}, fodselsdato=${fødselsdato}"

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -48,12 +48,7 @@ fun Route.søknadApis(
         søker.validate()
 
         val barn = resolveBarn(søknad, barnService, idToken, callId)
-        logger.info("barn id: {}", barn.norskIdentifikator) // TODO: 05/03/2021 Fjern prodsetting.
         søknad.oppdaterBarnsIdentitetsnummer(barn)
-        logger.info(
-            "oppdatert søknad med barn id: {}",
-            søknad.barn.norskIdentifikator
-        ) // TODO: 05/03/2021 Fjern prodsetting.
 
         logger.info("Mapper om søknad til k9format.")
         val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -48,7 +48,12 @@ fun Route.søknadApis(
         søker.validate()
 
         val barn = resolveBarn(søknad, barnService, idToken, callId)
+        logger.info("barn id: {}", barn.norskIdentifikator) // TODO: 05/03/2021 Fjern prodsetting.
         søknad.oppdaterBarnsIdentitetsnummer(barn)
+        logger.info(
+            "oppdatert søknad med barn id: {}",
+            søknad.barn.norskIdentifikator
+        ) // TODO: 05/03/2021 Fjern prodsetting.
 
         logger.info("Mapper om søknad til k9format.")
         val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
@@ -81,13 +86,8 @@ fun Route.søknadApis(
 
         val søker: Søker = søkerService.getSoker(idToken = idToken, callId = callId)
         val barn = resolveBarn(søknad, barnService, idToken, callId)
-        logger.info("barn id: {}", barn.norskIdentifikator) // TODO: 05/03/2021 Fjern prodsetting.
-        søknad.oppdaterBarnsIdentitetsnummer(barn)
 
-        logger.info(
-            "oppdatert søknad med barn id: {}",
-            søknad.barn.norskIdentifikator
-        ) // TODO: 05/03/2021 Fjern prodsetting.
+        søknad.oppdaterBarnsIdentitetsnummer(barn)
 
         val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
         søknad.valider(k9FormatSøknad)

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -6,6 +6,9 @@ import io.ktor.locations.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import no.nav.omsorgspenger.barn.BarnService
+import no.nav.omsorgspenger.general.CallId
+import no.nav.omsorgspenger.general.auth.IdToken
 import no.nav.omsorgspenger.general.auth.IdTokenProvider
 import no.nav.omsorgspenger.general.getCallId
 import no.nav.omsorgspenger.k9format.tilK9Format
@@ -23,7 +26,8 @@ private val logger: Logger = LoggerFactory.getLogger("nav.soknadApis")
 fun Route.søknadApis(
     søknadService: SøknadService,
     idTokenProvider: IdTokenProvider,
-    søkerService: SøkerService
+    søkerService: SøkerService,
+    barnService: BarnService
 ) {
 
     @Location("/soknad")
@@ -43,8 +47,10 @@ fun Route.søknadApis(
         logger.trace("Søker hentet. Validerer søkeren.")
         søker.validate()
 
+        val barn = resolveBarn(søknad, barnService, idToken, callId)
+
         logger.info("Mapper om søknad til k9format.")
-        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
+        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, barn)
 
         søknad.valider(k9FormatSøknad)
         logger.trace("Validering OK. Registrerer søknad.")
@@ -74,9 +80,40 @@ fun Route.søknadApis(
 
         val søker: Søker = søkerService.getSoker(idToken = idToken, callId = callId)
 
-        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
+        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, søknad.barn)
         søknad.valider(k9FormatSøknad)
         logger.trace("Validering Ok.")
         call.respond(HttpStatusCode.Accepted)
+    }
+}
+
+private suspend fun resolveBarn(
+    søknad: Søknad,
+    barnService: BarnService,
+    idToken: IdToken,
+    callId: CallId
+): BarnDetaljer = when {
+    // Gjelder annet barn enn fra oppslag
+    søknad.barn.aktørId.isNullOrBlank() -> søknad.barn
+
+    // Oppslagsbarn
+    else -> {
+        val barn = barnService.hentNaaverendeBarn(
+            idToken = idToken,
+            callId = callId
+        ).map {
+            BarnDetaljer(
+                norskIdentifikator = it.identitetsnummer,
+                fødselsdato = it.fødselsdato,
+                aktørId = it.aktørId,
+                navn = when (it.mellomnavn) {
+                    null, "" -> "${it.fornavn} ${it.etternavn}"
+                    else -> "${it.fornavn} ${it.mellomnavn} ${it.etternavn}"
+                }
+            )
+        }
+            .firstOrNull { it.aktørId == søknad.barn.aktørId }
+        barn
+            ?: throw IllegalStateException("Kunne ikke fimme barnets aktørId blant liste over oppslagsbarn.") // Burde ikke forekomme
     }
 }

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -48,9 +48,10 @@ fun Route.søknadApis(
         søker.validate()
 
         val barn = resolveBarn(søknad, barnService, idToken, callId)
+        søknad.oppdaterBarnsIdentitetsnummer(barn)
 
         logger.info("Mapper om søknad til k9format.")
-        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, barn)
+        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
 
         søknad.valider(k9FormatSøknad)
         logger.trace("Validering OK. Registrerer søknad.")
@@ -80,8 +81,9 @@ fun Route.søknadApis(
 
         val søker: Søker = søkerService.getSoker(idToken = idToken, callId = callId)
         val barn = resolveBarn(søknad, barnService, idToken, callId)
+        søknad.oppdaterBarnsIdentitetsnummer(barn)
 
-        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, barn)
+        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
         søknad.valider(k9FormatSøknad)
         logger.trace("Validering Ok.")
         call.respond(HttpStatusCode.Accepted)

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -79,8 +79,9 @@ fun Route.søknadApis(
         val callId = call.getCallId()
 
         val søker: Søker = søkerService.getSoker(idToken = idToken, callId = callId)
+        val barn = resolveBarn(søknad, barnService, idToken, callId)
 
-        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, søknad.barn)
+        val k9FormatSøknad = søknad.tilK9Format(mottatt, søker, barn)
         søknad.valider(k9FormatSøknad)
         logger.trace("Validering Ok.")
         call.respond(HttpStatusCode.Accepted)

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadApis.kt
@@ -81,7 +81,13 @@ fun Route.søknadApis(
 
         val søker: Søker = søkerService.getSoker(idToken = idToken, callId = callId)
         val barn = resolveBarn(søknad, barnService, idToken, callId)
+        logger.info("barn id: {}", barn.norskIdentifikator) // TODO: 05/03/2021 Fjern prodsetting.
         søknad.oppdaterBarnsIdentitetsnummer(barn)
+
+        logger.info(
+            "oppdatert søknad med barn id: {}",
+            søknad.barn.norskIdentifikator
+        ) // TODO: 05/03/2021 Fjern prodsetting.
 
         val k9FormatSøknad = søknad.tilK9Format(mottatt, søker)
         søknad.valider(k9FormatSøknad)

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
@@ -154,20 +154,7 @@ private fun BarnDetaljer.valider(relasjonTilBarnet: String?): MutableSet<Violati
         )
     }
 
-    if (!gyldigAntallIder()) {
-        violations.add(
-            Violation(
-                parameterName = "barn",
-                parameterType = ParameterType.ENTITY,
-                reason = "Kan kun sette 'aktørId' eller 'norskIdentifikator' på barnet.",
-                invalidValue = null
-            )
-        )
-    }
-
-
-    val kreverNavnPaaBarnet = norskIdentifikator != null
-    if ((kreverNavnPaaBarnet || navn != null) && (navn == null || navn.erBlankEllerLengreEnn(100))) {
+    if (navn.erBlankEllerLengreEnn(100)) {
         violations.add(
             Violation(
                 parameterName = "barn.navn",

--- a/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/soknad/SøknadValidator.kt
@@ -133,7 +133,7 @@ private fun BarnDetaljer.gyldigAntallIder(): Boolean {
 private fun BarnDetaljer.valider(relasjonTilBarnet: String?): MutableSet<Violation> {
     val violations = mutableSetOf<Violation>()
 
-    if (norskIdentifikator != null && !norskIdentifikator.erGyldigNorskIdentifikator()) {
+    if (norskIdentifikator.isNullOrBlank() || (!norskIdentifikator.erGyldigNorskIdentifikator())) {
         violations.add(
             Violation(
                 parameterName = "barn.norskIdentifikator",

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -67,4 +67,12 @@ nav {
         passphrase=""
         passphrase=${?STORAGE_PASSPHRASE}
     }
+    cache{
+        barn{
+            expiry_in_minutes = "30"
+            expiry_in_minutes = ${?CACHE_EXPIRY_IN_MINUTES}
+            max_size = "500"
+            max_size = ${?CACHE_MAX_SIZE}
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/omsorgspenger/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ApplicationTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.assertTrue
 private const val forLangtNavn =
     "DetteNavnetErForLangtDetteNavnetErForLangtDetteNavnetErForLangtDetteNavnetErForLangtDetteNavnetErForLangt"
 private const val fnr = "290990123456"
+private const val fnrB = "25118921464"
 private const val ikkeMyndigFnr = "12125012345"
 // Se https://github.com/navikt/dusseldorf-ktor#f%C3%B8dselsnummer
 private val gyldigFodselsnummerA = "02119970078"
@@ -162,7 +163,7 @@ class ApplicationTest {
                 "barn": []
             }
             """.trimIndent(),
-            cookie = getAuthCookie(fnr)
+            cookie = getAuthCookie(fnrB)
         )
         wireMockServer.stubK9OppslagBarn()
     }
@@ -250,7 +251,7 @@ class ApplicationTest {
 
     @Test //Denne testen fanger ikke opp om barnets navn blir satt eller ikke. Må undersøke loggen.
     fun `Sende søknad med AktørID som ID på barnet`() {
-        val cookie = getAuthCookie(gyldigFodselsnummerA)
+        val cookie = getAuthCookie(fnr)
         val jpegUrl = engine.jpegUrl(cookie)
         val pdfUrl = engine.pdUrl(cookie)
 
@@ -262,7 +263,7 @@ class ApplicationTest {
             cookie = cookie,
             requestEntity = SøknadUtils.gyldigSøknad(pdfUrl, jpegUrl).copy(
                 barn = BarnDetaljer(
-                    aktørId = "12345"
+                    aktørId = "1000000000001"
                 )
             ).somJson()
         )
@@ -313,7 +314,7 @@ class ApplicationTest {
                   "barn": {
                     "navn": "$forLangtNavn",
                     "norskIdentifikator": "29099012345",
-                    "aktørId": "123456"
+                    "aktørId": "1000000000001"
                   },
                   "sammeAddresse": true,
                   "relasjonTilBarnet": "mor",

--- a/src/test/kotlin/no/nav/omsorgspenger/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ApplicationTest.kt
@@ -263,6 +263,7 @@ class ApplicationTest {
             cookie = cookie,
             requestEntity = SøknadUtils.gyldigSøknad(pdfUrl, jpegUrl).copy(
                 barn = BarnDetaljer(
+                    navn = "BARN EN BARNESEN",
                     aktørId = "1000000000001"
                 )
             ).somJson()
@@ -337,18 +338,6 @@ class ApplicationTest {
                   "detail": "Requesten inneholder ugyldige paramtere.",
                   "instance": "about:blank",
                   "invalid_parameters": [
-                    {
-                      "type": "entity",
-                      "name": "barn.norskIdentifikator",
-                      "reason": "Ikke gyldig norskIdentifikator.",
-                      "invalid_value": "29099012345"
-                    },
-                    {
-                      "type": "entity",
-                      "name": "barn",
-                      "reason": "Kan kun sette 'aktørId' eller 'norskIdentifikator' på barnet.",
-                      "invalid_value": null
-                    },
                     {
                       "type": "entity",
                       "name": "barn.navn",

--- a/src/test/kotlin/no/nav/omsorgspenger/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SøknadUtils.kt
@@ -22,6 +22,11 @@ class SøknadUtils {
             fødselsnummer = "26104500284"
         )
 
+        val barn = BarnDetaljer(
+            norskIdentifikator = "02119970078",
+            navn = "Ole Dole Doffen"
+        )
+
         fun gyldigSøknad(legeerklæringURL: String? = null, samværsavtalURL: String? = null): Søknad {
             val legeerklæring = if (legeerklæringURL != null) listOf(URL(legeerklæringURL)) else listOf()
             val samværsavtale = if (samværsavtalURL != null) listOf(URL(samværsavtalURL)) else listOf()
@@ -30,10 +35,7 @@ class SøknadUtils {
                 nyVersjon = false,
                 språk = "nb",
                 kroniskEllerFunksjonshemming = false,
-                barn = BarnDetaljer(
-                    norskIdentifikator = "02119970078",
-                    navn = "Ole Dole Doffen"
-                ),
+                barn = barn,
                 sammeAdresse = true,
                 relasjonTilBarnet = SøkerBarnRelasjon.FAR,
                 legeerklæring = legeerklæring,

--- a/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
@@ -40,18 +40,6 @@ internal class SøknadValideringsTest {
     }
 
     @Test(expected = Throwblem::class)
-    fun `Forvent violation dersom barn har både aktørID og norskIdentnummer`() {
-        val søknad = gyldigSøknad.copy(
-            barn = BarnDetaljer(
-                navn = "Ole Dole Doffen",
-                norskIdentifikator = "02119970078",
-                aktørId = "1234"
-            )
-        )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
-    }
-
-    @Test(expected = Throwblem::class)
     fun `Forvent violation dersom barn norskIdentnummer er null`() {
         val søknad = gyldigSøknad.copy(
             barn = BarnDetaljer(

--- a/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
@@ -1,7 +1,6 @@
 package no.nav.omsorgspenger
 
 import no.nav.helse.dusseldorf.ktor.core.Throwblem
-import no.nav.omsorgspenger.SøknadUtils.Companion.barn
 import no.nav.omsorgspenger.SøknadUtils.Companion.søker
 import no.nav.omsorgspenger.k9format.tilK9Format
 import no.nav.omsorgspenger.soknad.BarnDetaljer
@@ -19,7 +18,7 @@ internal class SøknadValideringsTest {
 
     @Test
     fun `Skal ikke feile på gyldig søknad`() {
-        gyldigSøknad.valider(gyldigSøknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        gyldigSøknad.valider(gyldigSøknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test
@@ -37,7 +36,7 @@ internal class SøknadValideringsTest {
                 aktørId = null
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -49,7 +48,7 @@ internal class SøknadValideringsTest {
                 aktørId = "1234"
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -60,7 +59,7 @@ internal class SøknadValideringsTest {
                 norskIdentifikator = null
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -71,7 +70,7 @@ internal class SøknadValideringsTest {
                 norskIdentifikator = "  "
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -79,7 +78,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             samværsavtale = listOf()
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -87,7 +86,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             samværsavtale = listOf(URL("http://localhost/FEIL/1"))
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -95,7 +94,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             harBekreftetOpplysninger = false
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 
     @Test(expected = Throwblem::class)
@@ -103,6 +102,6 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             harForståttRettigheterOgPlikter = false
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker))
     }
 }

--- a/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/SøknadValidationTest.kt
@@ -1,6 +1,8 @@
 package no.nav.omsorgspenger
 
 import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import no.nav.omsorgspenger.SøknadUtils.Companion.barn
+import no.nav.omsorgspenger.SøknadUtils.Companion.søker
 import no.nav.omsorgspenger.k9format.tilK9Format
 import no.nav.omsorgspenger.soknad.BarnDetaljer
 import no.nav.omsorgspenger.soknad.starterMedFodselsdato
@@ -17,7 +19,7 @@ internal class SøknadValideringsTest {
 
     @Test
     fun `Skal ikke feile på gyldig søknad`() {
-        gyldigSøknad.valider(gyldigSøknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        gyldigSøknad.valider(gyldigSøknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test
@@ -35,7 +37,7 @@ internal class SøknadValideringsTest {
                 aktørId = null
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -47,7 +49,7 @@ internal class SøknadValideringsTest {
                 aktørId = "1234"
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -58,7 +60,7 @@ internal class SøknadValideringsTest {
                 norskIdentifikator = null
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -69,7 +71,7 @@ internal class SøknadValideringsTest {
                 norskIdentifikator = "  "
             )
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -77,7 +79,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             samværsavtale = listOf()
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -85,7 +87,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             samværsavtale = listOf(URL("http://localhost/FEIL/1"))
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -93,7 +95,7 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             harBekreftetOpplysninger = false
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 
     @Test(expected = Throwblem::class)
@@ -101,6 +103,6 @@ internal class SøknadValideringsTest {
         val søknad = gyldigSøknad.copy(
             harForståttRettigheterOgPlikter = false
         )
-        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), SøknadUtils.søker))
+        søknad.valider(søknad.tilK9Format(ZonedDateTime.now(), søker, barn))
     }
 }

--- a/src/test/kotlin/no/nav/omsorgspenger/wiremock/BarnResponseTransformer.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/wiremock/BarnResponseTransformer.kt
@@ -43,13 +43,15 @@ private fun getResponse(ident: String): String {
                     "fornavn": "BARN",
                     "mellomnavn": "EN",
                     "etternavn": "BARNESEN",
-                    "aktør_id": "1000000000001"
+                    "aktør_id": "1000000000001",
+                    "identitetsnummer": "02119970078"
                 }, {
                     "fødselsdato": "2001-04-10",
                     "fornavn": "BARN",
                     "mellomnavn": "TO",
                     "etternavn": "BARNESEN",
-                    "aktør_id": "1000000000002"
+                    "aktør_id": "1000000000002",
+                    "identitetsnummer": "02110170078"
                 }]
             }
             """.trimIndent()


### PR DESCRIPTION
- Cacher liste over barn pr. søker.
- Oppløser barn sendt inn. Dersom aktørId mangler antar vi at det gjelder annet barn enn fra oppslag. Ellers henter vi barn på nytt med identitetsnummer.
- setter kun identitetsnummer på barn mappet til k9Format